### PR TITLE
fixed toFormalString in range

### DIFF
--- a/lib/range.js
+++ b/lib/range.js
@@ -112,10 +112,10 @@ Range.prototype.toFormalString = function() {
   }
   range += '/';
 
-  if(this.duration) {
-    range += this.duration.toFormalString();
-  } else if(this.end) {
+  if (this.end) {
     range += this.end.toFormalString();
+  } else if (this.duration) {
+    range += this.duration.toFormalString();
   }
 
   return range;


### PR DESCRIPTION
Changed toFormalString to default to end date instead of using the duration from start date